### PR TITLE
fix: doesn't spoof some classes

### DIFF
--- a/NameSpoofer/index.js
+++ b/NameSpoofer/index.js
@@ -53,7 +53,7 @@ window.addEventListener("load", () => {
                 elements.forEach((element) => {
                     element.textContent = name;
                 });
-            }).observe(manager, {
+            }).observe(document, {
                 childList: true,
                 subtree: true,
             });


### PR DESCRIPTION
it's a problem that doesn't happen all the time, but sometimes MutationObserver.observe(manager) can't see some changes in specific classes